### PR TITLE
Suggestion in order to be able to use ExtCore for netstandard1.6

### DIFF
--- a/ExtCore.Tests/ExtCore.Tests.fsproj
+++ b/ExtCore.Tests/ExtCore.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netcoreapp2.0;net45</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestHelpers.fs" />

--- a/ExtCore.Tests/Pervasive.fs
+++ b/ExtCore.Tests/Pervasive.fs
@@ -180,12 +180,12 @@ module Operators =
     let typehandleof () : unit =
         Assert.Ignore "Test not yet implemented."
 #endif
-
+#if !NETSTANDARD1_6
     [<Test>]
     let raiseNew () : unit =
         Assert.Throws<System.NotFiniteNumberException>(fun () ->
             raiseNew<System.NotFiniteNumberException, _> ()) |> ignore
-
+#endif
     /// Checks for a non-empty exeption message.
     let private NonEmptyExceptionMessage (ex : exn) : unit =
         Assert.IsNotNull ex.Message

--- a/ExtCore/AssemblyInfo.fs
+++ b/ExtCore/AssemblyInfo.fs
@@ -26,7 +26,7 @@ open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
 open System.Security
 
-#if FX_ATLEAST_PORTABLE
+#if FX_ATLEAST_PORTABLE || NETSTANDARD1_6
 #else
 open System.Security.Permissions
 #endif
@@ -54,7 +54,7 @@ open System.Security.Permissions
     to the test project so they can be unit-tested. *)
 [<assembly: InternalsVisibleTo("ExtCore.Tests")>]
 
-#if FX_ATLEAST_PORTABLE
+#if FX_ATLEAST_PORTABLE || NETSTANDARD1_6
 #else
 (* Dependency hints for Ngen *)
 [<assembly: DependencyAttribute("FSharp.Core", LoadHint.Always)>]

--- a/ExtCore/Collections.ResizeArray.fs
+++ b/ExtCore/Collections.ResizeArray.fs
@@ -709,7 +709,7 @@ let inline map (mapping : 'T -> 'U) (resizeArray : ResizeArray<'T>) : ResizeArra
     // Preconditions
     checkNonNull "resizeArray" resizeArray
 
-    #if FX_ATLEAST_PORTABLE
+    #if FX_ATLEAST_PORTABLE || NETSTANDARD1_6
     // Simple implementation for portable libraries.
     let results = ResizeArray (resizeArray.Count)
     for i = 0 to resizeArray.Count - 1 do

--- a/ExtCore/Collections.Vector.fs
+++ b/ExtCore/Collections.Vector.fs
@@ -58,7 +58,7 @@ type vector<'T> private (elements : 'T[]) =
         with get () =
             elements.Length
 
-#if FX_ATLEAST_PORTABLE
+#if FX_ATLEAST_PORTABLE || NETSTANDARD1_6
 #else
     /// Gets a 64-bit integer that represents the total number of elements in the Vector.
     member __.LongLength

--- a/ExtCore/ExtCore.fsproj
+++ b/ExtCore/ExtCore.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+        <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
         <Title>AzureBillingApi</Title>
         <Version>0.8.47</Version>
         <RepositoryUrl>https://github.com/jack-pappas/ExtCore</RepositoryUrl>

--- a/ExtCore/Net.fs
+++ b/ExtCore/Net.fs
@@ -18,7 +18,7 @@ limitations under the License.
 
 namespace ExtCore.Net
 
-#if FX_ATLEAST_PORTABLE
+#if FX_ATLEAST_PORTABLE || NETSTANDARD1_6
 #else
 
 open System

--- a/ExtCore/Pervasive.fs
+++ b/ExtCore/Pervasive.fs
@@ -1371,7 +1371,7 @@ module Printf =
     let inline dprintfn format : 'T =
         ksprintf Debug.WriteLine format
 
-#if FX_SIMPLE_DIAGNOSTICS
+#if FX_SIMPLE_DIAGNOSTICS || NETSTANDARD1_6
 #else
     /// <summary>Print formatted string to Debug listeners.</summary>
     /// <param name="format"></param>


### PR DESCRIPTION
A suggestion in order to solve #26 it's sort of the same as https://github.com/jack-pappas/ExtCore/issues/26#issuecomment-321530355, except it uses the predefined `NETSTANDARD1_6 ` compiler flag