### PR TITLE
Appveyor fix, run tests for netstandard1.6 via netcoreapp1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ sudo: required
 # TODO : Enable both mono and dotnet builds: https://docs.travis-ci.com/user/languages/csharp/#Testing-Against-Mono-and-.NET-Core
 mono:
   - latest
-dotnet: 
-  - 2.0.0
-  - 1.1.5
 env: MONO_BASE_PATH=/usr/lib/mono/
+
+matrix:
+  include:
+    - dotnet: 2.0.0
+      env: DOTNETFW=netcoreapp2.0
+    - dotnet: 1.1.5
+      env: DOTNETFW=netcoreapp1.1
 
 install:
   - dotnet restore
@@ -22,10 +26,9 @@ install:
 #        https://docs.travis-ci.com/user/customizing-the-build/#Explicitly-Including-Jobs
 
 script:
-  - dotnet build ExtCore/ExtCore.fsproj --framework "netstandard2.0"
+  - dotnet build ExtCore/ExtCore.fsproj --framework "$DOTNETFW"
   - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet build ExtCore/ExtCore.fsproj --framework "net45"
-  - dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "netcoreapp2.0"
-  - dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "netcoreapp1.1"
+  - dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "$DOTNETFW"
 #  - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "net45"
 # Workaround for dotnet test on net45:
   - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet build ExtCore.Tests/ExtCore.Tests.fsproj --framework "net45"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ sudo: required
 # TODO : Enable both mono and dotnet builds: https://docs.travis-ci.com/user/languages/csharp/#Testing-Against-Mono-and-.NET-Core
 mono:
   - latest
-env: MONO_BASE_PATH=/usr/lib/mono/
 
 matrix:
   include:
@@ -16,10 +15,12 @@ matrix:
       env: 
         - DOTNETLIBFW=netstandard2.0
         - DOTNETFW=netcoreapp2.0
+        - MONO_BASE_PATH=/usr/lib/mono/
     - dotnet: 1.1.0
       env:  
         - DOTNETLIBFW=netstandard1.6
         - DOTNETFW=netcoreapp1.1
+        - MONO_BASE_PATH=/usr/lib/mono/
 
 install:
   - dotnet restore

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   include:
     - dotnet: 2.0.0
       env: DOTNETFW=netcoreapp2.0
-    - dotnet: 1.1.5
+    - dotnet: 1.1.0
       env: DOTNETFW=netcoreapp1.1
 
 install:
@@ -26,9 +26,9 @@ install:
 #        https://docs.travis-ci.com/user/customizing-the-build/#Explicitly-Including-Jobs
 
 script:
-  - dotnet build ExtCore/ExtCore.fsproj --framework "$DOTNETFW"
+  - dotnet build ExtCore/ExtCore.fsproj --framework $DOTNETFW
   - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet build ExtCore/ExtCore.fsproj --framework "net45"
-  - dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "$DOTNETFW"
+  - dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework $DOTNETFW
 #  - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "net45"
 # Workaround for dotnet test on net45:
   - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet build ExtCore.Tests/ExtCore.Tests.fsproj --framework "net45"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ env: MONO_BASE_PATH=/usr/lib/mono/
 matrix:
   include:
     - dotnet: 2.0.0
-      env: DOTNETLIBFW=netstandard2.0
-      env: DOTNETFW=netcoreapp2.0
+      env: 
+        - DOTNETLIBFW=netstandard2.0
+        - DOTNETFW=netcoreapp2.0
     - dotnet: 1.1.0
-      env: DOTNETLIBFW=netstandard1.6
-      env: DOTNETFW=netcoreapp1.1
+      env:  
+        - DOTNETLIBFW=netstandard1.6
+        - DOTNETFW=netcoreapp1.1
 
 install:
   - dotnet restore

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       env: DOTNETFW=netcoreapp1.1
 
 install:
-  - dotnet restore
+  - dotnet restore --framework $DOTNETFW
 
 # TODO : Add before_script section to clone fsharp/fsharp repo and compile it, so fsc-proto can be used.
 #        Cache the compiled fsharp build (using travis CI caching functionality) so it doesn't have to run every time.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ env: MONO_BASE_PATH=/usr/lib/mono/
 matrix:
   include:
     - dotnet: 2.0.0
+      env: DOTNETLIBFW=netstandard2.0
       env: DOTNETFW=netcoreapp2.0
     - dotnet: 1.1.0
+      env: DOTNETLIBFW=netstandard1.6
       env: DOTNETFW=netcoreapp1.1
 
 install:
-  - dotnet restore --framework $DOTNETFW
+  - dotnet restore
 
 # TODO : Add before_script section to clone fsharp/fsharp repo and compile it, so fsc-proto can be used.
 #        Cache the compiled fsharp build (using travis CI caching functionality) so it doesn't have to run every time.
@@ -26,7 +28,7 @@ install:
 #        https://docs.travis-ci.com/user/customizing-the-build/#Explicitly-Including-Jobs
 
 script:
-  - dotnet build ExtCore/ExtCore.fsproj --framework $DOTNETFW
+  - dotnet build ExtCore/ExtCore.fsproj --framework $DOTNETLIBFW
   - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet build ExtCore/ExtCore.fsproj --framework "net45"
   - dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework $DOTNETFW
 #  - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "net45"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - dotnet build ExtCore/ExtCore.fsproj --framework "netstandard2.0"
   - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet build ExtCore/ExtCore.fsproj --framework "net45"
   - dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "netcoreapp2.0"
+  - dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "netcoreapp1.1"
 #  - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet test ExtCore.Tests/ExtCore.Tests.fsproj --framework "net45"
 # Workaround for dotnet test on net45:
   - FrameworkPathOverride=$MONO_BASE_PATH/4.5-api/ dotnet build ExtCore.Tests/ExtCore.Tests.fsproj --framework "net45"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ sudo: required
 # TODO : Enable both mono and dotnet builds: https://docs.travis-ci.com/user/languages/csharp/#Testing-Against-Mono-and-.NET-Core
 mono:
   - latest
-dotnet: 2.0.0
+dotnet: 
+  - 2.0.0
+  - 1.1.5
 env: MONO_BASE_PATH=/usr/lib/mono/
 
 install:

--- a/ExtCore.Tests/ExtCore.Tests.fsproj
+++ b/ExtCore.Tests/ExtCore.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netcoreapp2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net45</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestHelpers.fs" />

--- a/ExtCore.Tests/Pervasive.fs
+++ b/ExtCore.Tests/Pervasive.fs
@@ -180,7 +180,7 @@ module Operators =
     let typehandleof () : unit =
         Assert.Ignore "Test not yet implemented."
 #endif
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_6 && !NETCOREAPP1_1
     [<Test>]
     let raiseNew () : unit =
         Assert.Throws<System.NotFiniteNumberException>(fun () ->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,6 @@ build_script:
     dotnet build ExtCore.sln
 - cmd: >-
     dotnet test ExtCore.Tests\ExtCore.Tests.fsproj
-- cmd >-
+- cmd: >-
     dotnet pack
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ image: Visual Studio 2017
 build_script:
 - ps: >-
     ./install_dotnet.ps1
+- ps: >-
     ./install_dotnet.ps1 -Version 1.1.5
 - cmd: >-
     dotnet --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ image: Visual Studio 2017
 build_script:
 - ps: >-
     ./install_dotnet.ps1
+    ./install_dotnet.ps1 -Version 1.1.5
 - cmd: >-
     dotnet --version
 - cmd: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,3 +12,4 @@ build_script:
 - cmd: >-
     dotnet pack
 test: off
+

--- a/install_dotnet.ps1
+++ b/install_dotnet.ps1
@@ -393,8 +393,12 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolde
 $AzureChannel = Get-Azure-Channel-From-Channel -Channel $Channel
 $CLIArchitecture = Get-CLIArchitecture-From-Architecture $Architecture
 $SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $AzureFeed -AzureChannel $AzureChannel -CLIArchitecture $CLIArchitecture -Version $Version
-# $DownloadLinks = Get-Download-Links -AzureFeed $AzureFeed -AzureChannel $AzureChannel -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
-$DownloadLinks = @("https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x64.zip")
+if($Version -eq "Latest") {
+    $DownloadLinks = @("https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x64.zip")
+} else {
+    $DownloadLinks = Get-Download-Links -AzureFeed $AzureFeed -AzureChannel $AzureChannel -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+}
+
 
 if ($DryRun) {
     Say "Payload URLs:"


### PR DESCRIPTION
Following https://github.com/jack-pappas/ExtCore/issues/35#issuecomment-345956400, I found issue of appveyor being red is because netstandard1.6 tests is not actually working.

This add testing of netstandard1.6 on .NET Core 1.1 to both appveyor and travis.