### PR TITLE
Fix Error in ResizeArray.init

### DIFF
--- a/ExtCore/Collections.ResizeArray.fs
+++ b/ExtCore/Collections.ResizeArray.fs
@@ -71,7 +71,7 @@ let init count initializer : ResizeArray<'T> =
 
     let resizeArray = ResizeArray (count)
     for i = 0 to count - 1 do
-        resizeArray.Add <| initializer count
+        resizeArray.Add <| initializer i
     resizeArray
 
 /// Adds an object to the end of the ResizeArray.


### PR DESCRIPTION
I believe the initializer should be called with 'i' not 'count' like in Array.init here: https://github.com/dotnet/fsharp/blob/ec5bad3a391357e03ff2286a264f0e4faf7d840d/src/fsharp/FSharp.Core/local.fs#L997